### PR TITLE
Update nhrp_peer.h

### DIFF
--- a/nhrp/nhrp_peer.h
+++ b/nhrp/nhrp_peer.h
@@ -137,7 +137,7 @@ struct nhrp_peer_selector {
 	struct nhrp_address local_nbma_address;
 };
 
-const char * const nhrp_peer_type[NHRP_PEER_TYPE_MAX];
+extern const char * const nhrp_peer_type[NHRP_PEER_TYPE_MAX];
 typedef int (*nhrp_peer_enumerator)(void *ctx, struct nhrp_peer *peer);
 
 void nhrp_peer_cleanup(void);


### PR DESCRIPTION
Fixed multiple definition of `nhrp_peer_type`. Error description:

/usr/bin/ld: nhrp/nhrp_packet.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: multiple definition of `nhrp_peer_type'; nhrp/opennhrp.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: first defined here
/usr/bin/ld: nhrp/nhrp_peer.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: multiple definition of `nhrp_peer_type'; nhrp/opennhrp.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: first defined here
/usr/bin/ld: nhrp/nhrp_server.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: multiple definition of `nhrp_peer_type'; nhrp/opennhrp.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: first defined here
/usr/bin/ld: nhrp/nhrp_interface.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: multiple definition of `nhrp_peer_type'; nhrp/opennhrp.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: first defined here
/usr/bin/ld: nhrp/admin.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: multiple definition of `nhrp_peer_type'; nhrp/opennhrp.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: first defined here
/usr/bin/ld: nhrp/sysdep_netlink.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: multiple definition of `nhrp_peer_type'; nhrp/opennhrp.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: first defined here
/usr/bin/ld: nhrp/sysdep_pfpacket.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: multiple definition of `nhrp_peer_type'; nhrp/opennhrp.o:/opt/opennhrp/nhrp/nhrp_peer.h:139: first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [Make.rules:215: nhrp/opennhrp] Error 1
make: *** [Make.rules:246: nhrp/] Error 2

gcc version: 11.3.0
make: 4.3